### PR TITLE
Add package initialization and local imports

### DIFF
--- a/01_JusticeDB_Import.py
+++ b/01_JusticeDB_Import.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 import pandas as pd
 import urllib
 import sqlalchemy
-from etl_sandbox.db.mssql import get_target_connection
+from db.mssql import get_target_connection
 from botocore.exceptions import ClientError
 from tqdm import tqdm
 from sqlalchemy.types import Text

--- a/02_OperationsDB_Import.py
+++ b/02_OperationsDB_Import.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 import pandas as pd
 import urllib
 import sqlalchemy
-from etl_sandbox.db.mssql import get_target_connection
+from db.mssql import get_target_connection
 from botocore.exceptions import ClientError
 from tqdm import tqdm
 from sqlalchemy.types import Text

--- a/03_FinancialDB_Import.py
+++ b/03_FinancialDB_Import.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 import pandas as pd
 import urllib
 import sqlalchemy
-from etl_sandbox.db.mssql import get_target_connection
+from db.mssql import get_target_connection
 from botocore.exceptions import ClientError
 from tqdm import tqdm
 from sqlalchemy.types import Text

--- a/04_LOBColumns.py
+++ b/04_LOBColumns.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 import pandas as pd
 import urllib
 import sqlalchemy
-from etl_sandbox.db.mssql import get_target_connection
+from db.mssql import get_target_connection
 from botocore.exceptions import ClientError
 from tqdm import tqdm
 from sqlalchemy.types import Text

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,13 @@
+"""Configuration settings for database connections."""
+
+from .settings import (
+    MSSQL_SOURCE_CONN_STR,
+    MSSQL_TARGET_CONN_STR,
+    MYSQL_CONN_DICT,
+)
+
+__all__ = [
+    "MSSQL_SOURCE_CONN_STR",
+    "MSSQL_TARGET_CONN_STR",
+    "MYSQL_CONN_DICT",
+]

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,0 +1,10 @@
+"""Database connection utilities."""
+
+from .mssql import get_source_connection, get_target_connection
+from .mysql import get_mysql_connection
+
+__all__ = [
+    "get_source_connection",
+    "get_target_connection",
+    "get_mysql_connection",
+]

--- a/db/mssql.py
+++ b/db/mssql.py
@@ -1,5 +1,5 @@
 import pyodbc
-from etl_sandbox.config.settings import MSSQL_SOURCE_CONN_STR, MSSQL_TARGET_CONN_STR
+from config.settings import MSSQL_SOURCE_CONN_STR, MSSQL_TARGET_CONN_STR
 
 def get_mssql_connection(conn_str):
     return pyodbc.connect(conn_str)
@@ -9,3 +9,4 @@ def get_source_connection():
 
 def get_target_connection():
     return get_mssql_connection(MSSQL_TARGET_CONN_STR)
+

--- a/db/mysql.py
+++ b/db/mysql.py
@@ -7,7 +7,7 @@ load_dotenv()
 
 # Import Config from settings.py
 try:
-    from etl_sandbox.settings import Config
+    from config.settings import Config
 except ImportError:
     Config = None
 


### PR DESCRIPTION
## Summary
- expose connection settings and helpers as packages
- reference `config` and `db` packages instead of `etl_sandbox`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684995c9acc08323a13a5e39ce25eeef