### PR TITLE
Use EJ_CSV_DIR for csv paths

### DIFF
--- a/01_JusticeDB_Import.py
+++ b/01_JusticeDB_Import.py
@@ -100,7 +100,12 @@ def main():
         db_url = f"mssql+pyodbc:///?odbc_connect={params}"
         engine = sqlalchemy.create_engine(db_url)
 
-        df = pd.read_csv(r'C:\Users\jeff.reichert\OneDrive - Tyler Technologies, Inc\Documents\GitHub\tx_elpaso_7373\Pre-DMS\EJ_Justice_Selects_ALL.csv', delimiter='|')
+        csv_dir = os.environ.get("EJ_CSV_DIR")
+        if not csv_dir:
+            raise EnvironmentError("EJ_CSV_DIR environment variable is not set")
+        csv_path = os.path.join(csv_dir, "EJ_Justice_Selects.csv")
+
+        df = pd.read_csv(csv_path, delimiter='|')
         df = df.astype({'DatabaseName': 'str','SchemaName': 'str','TableName': 'str','Freq': 'str','InScopeFreq': 'str','Select_Only': 'str','fConvert': 'str','Drop_IfExists': 'str','Selection': 'str','Select_Into': 'str'})
         df.to_sql(
             'TableUsedSelects',

--- a/02_OperationsDB_Import.py
+++ b/02_OperationsDB_Import.py
@@ -88,7 +88,12 @@ def main():
         db_url = f"mssql+pyodbc:///?odbc_connect={params}"
         engine = sqlalchemy.create_engine(db_url)
 
-        df = pd.read_csv(r'C:\Users\jeff.reichert\OneDrive - Tyler Technologies, Inc\Documents\GitHub\tx_elpaso_7373\Pre-DMS\EJ_Operations_Selects_ALL.csv', delimiter='|')
+        csv_dir = os.environ.get("EJ_CSV_DIR")
+        if not csv_dir:
+            raise EnvironmentError("EJ_CSV_DIR environment variable is not set")
+        csv_path = os.path.join(csv_dir, "EJ_Operations_Selects.csv")
+
+        df = pd.read_csv(csv_path, delimiter='|')
         df = df.astype({'DatabaseName': 'str','SchemaName': 'str','TableName': 'str','Freq': 'str','InScopeFreq': 'str','Select_Only': 'str','fConvert': 'str','Drop_IfExists': 'str','Selection': 'str','Select_Into': 'str'})
         df.to_sql(
             'TableUsedSelects_Operations',

--- a/03_FinancialDB_Import.py
+++ b/03_FinancialDB_Import.py
@@ -89,7 +89,12 @@ def main():
         db_url = f"mssql+pyodbc:///?odbc_connect={params}"
         engine = sqlalchemy.create_engine(db_url)
 
-        df = pd.read_csv(r'C:\Users\jeff.reichert\OneDrive - Tyler Technologies, Inc\Documents\GitHub\tx_elpaso_7373\Pre-DMS\EJ_Financial_Selects_ALL.csv', delimiter='|')
+        csv_dir = os.environ.get("EJ_CSV_DIR")
+        if not csv_dir:
+            raise EnvironmentError("EJ_CSV_DIR environment variable is not set")
+        csv_path = os.path.join(csv_dir, "EJ_Financial_Selects.csv")
+
+        df = pd.read_csv(csv_path, delimiter='|')
         df = df.astype({'DatabaseName': 'str','SchemaName': 'str','TableName': 'str','Freq': 'str','InScopeFreq': 'str','Select_Only': 'str','fConvert': 'str','Drop_IfExists': 'str','Selection': 'str','Select_Into': 'str'})
         df.to_sql(
             'TableUsedSelects_Financial',


### PR DESCRIPTION
## Summary
- read CSV paths from new `EJ_CSV_DIR` env var
- build `EJ_<DB>_Selects.csv` paths
- error if env var missing

## Testing
- `python -m py_compile 01_JusticeDB_Import.py 02_OperationsDB_Import.py 03_FinancialDB_Import.py`

------
https://chatgpt.com/codex/tasks/task_e_68499680cc808323b78b7b42d5276ac7