### PR TITLE
Refactor ETL helper functions

### DIFF
--- a/01_JusticeDB_Import.py
+++ b/01_JusticeDB_Import.py
@@ -12,58 +12,17 @@ from sqlalchemy.types import Text
 import tkinter as tk
 from tkinter import messagebox
 
+from utils.etl_helpers import (
+    log_exception_to_file,
+    load_sql,
+    run_sql_step,
+    run_sql_script,
+)
+
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
 
-def log_exception_to_file(error_details, log_path=r"C:\LargeFileHolder\7373\PreDMSErrorLog_Justice.txt"):
-    try:
-        with open(log_path, "a", encoding="utf-8") as f:
-            f.write(error_details + "\n")
-    except Exception as file_exc:
-        logger.error(f"Failed to write to error log file: {file_exc}")
-def load_sql(filename):
-    base_dir = os.path.dirname(__file__)
-    sql_path = os.path.join(base_dir, 'sql_scripts', filename)
-    if not os.path.exists(sql_path):
-        logger.error(f"SQL file not found: {sql_path}")
-        raise FileNotFoundError(f"SQL file not found: {sql_path}")
-    with open(sql_path, 'r', encoding='utf-8') as f:
-        return f.read()
-def run_sql_step(conn, name, sql):
-    logger.info(f"Starting step: {name}")
-    start_time = time.time()
-    try:
-        cursor = conn.cursor()
-        cursor.execute(sql)
-        try:
-            results = cursor.fetchall()
-            logger.info(f"{name}: Retrieved {len(results)} rows")
-        except Exception:
-            results = None
-            logger.info(f"{name}: Statement executed (no results to fetch)")
-        cursor.close()
-        elapsed = time.time() - start_time
-        logger.info(f"Completed step: {name} in {elapsed:.2f} seconds")
-        return results
-    except Exception as e:
-        logger.error(f"Error in step {name}: {str(e)}")
-        raise
-def run_sql_script(conn, name, sql):
-    logger.info(f"Starting script: {name}")
-    start_time = time.time()
-    try:
-        cursor = conn.cursor()
-        # Split on semicolon, filter out empty statements
-        statements = [stmt.strip() for stmt in sql.split(';') if stmt.strip()]
-        for stmt in statements:
-            cursor.execute(stmt)
-            conn.commit()  # Commit after each statement
-        cursor.close()
-        elapsed = time.time() - start_time
-        logger.info(f"Completed script: {name} in {elapsed:.2f} seconds")
-    except Exception as e:
-        logger.error(f"Error in script {name}: {str(e)}")
-        raise
+LOG_FILE = r"C:\\LargeFileHolder\\7373\\PreDMSErrorLog_Justice.txt"
 
 def main():
     load_dotenv()
@@ -154,7 +113,10 @@ def main():
                         
                 except Exception as e:
                     logger.error(f"Error executing statements for row {idx} (Justice.{full_table_name}): {e}")
-                    log_exception_to_file(f"Error executing statements for row {idx} (Justice.{full_table_name}): {e}")
+                    log_exception_to_file(
+                        f"Error executing statements for row {idx} (Justice.{full_table_name}): {e}",
+                        LOG_FILE,
+                    )
 
         cursor.close()
         logger.info("All Drop_IfExists and Select_Into statements executed for the JUSTICE Database")
@@ -181,7 +143,10 @@ def main():
                 target_conn.commit()
             except Exception as e:
                 logger.error(f"Error executing PK statements for row {idx} (Justice.{full_table_name}): {e}")
-                log_exception_to_file(f"Error executing PK statements for row {idx} (Justice.{full_table_name}): {e}")
+                log_exception_to_file(
+                    f"Error executing PK statements for row {idx} (Justice.{full_table_name}): {e}",
+                    LOG_FILE,
+                )
 
         cursor.close()
         logger.info("All Primary Key/NOT NULL statements executed FOR THE JUSTICE DATABASE.")
@@ -205,7 +170,7 @@ def main():
         logger.exception("Unexpected error")
         import traceback
         error_details = traceback.format_exc()
-        log_exception_to_file(error_details)  # <-- Add this line
+        log_exception_to_file(error_details, LOG_FILE)
         try:
             root = tk.Tk()
             root.withdraw()  # Hide the main window

--- a/02_OperationsDB_Import.py
+++ b/02_OperationsDB_Import.py
@@ -12,58 +12,17 @@ from sqlalchemy.types import Text
 import tkinter as tk
 from tkinter import messagebox
 
+from utils.etl_helpers import (
+    log_exception_to_file,
+    load_sql,
+    run_sql_step,
+    run_sql_script,
+)
+
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
 
-def log_exception_to_file(error_details, log_path=r"C:\LargeFileHolder\7373\PreDMSErrorLog_Operations.txt"):
-    try:
-        with open(log_path, "a", encoding="utf-8") as f:
-            f.write(error_details + "\n")
-    except Exception as file_exc:
-        logger.error(f"Failed to write to error log file: {file_exc}")
-def load_sql(filename):
-    base_dir = os.path.dirname(__file__)
-    sql_path = os.path.join(base_dir, 'sql_scripts', filename)
-    if not os.path.exists(sql_path):
-        logger.error(f"SQL file not found: {sql_path}")
-        raise FileNotFoundError(f"SQL file not found: {sql_path}")
-    with open(sql_path, 'r', encoding='utf-8') as f:
-        return f.read()
-def run_sql_step(conn, name, sql):
-    logger.info(f"Starting step: {name}")
-    start_time = time.time()
-    try:
-        cursor = conn.cursor()
-        cursor.execute(sql)
-        try:
-            results = cursor.fetchall()
-            logger.info(f"{name}: Retrieved {len(results)} rows")
-        except Exception:
-            results = None
-            logger.info(f"{name}: Statement executed (no results to fetch)")
-        cursor.close()
-        elapsed = time.time() - start_time
-        logger.info(f"Completed step: {name} in {elapsed:.2f} seconds")
-        return results
-    except Exception as e:
-        logger.error(f"Error in step {name}: {str(e)}")
-        raise
-def run_sql_script(conn, name, sql):
-    logger.info(f"Starting script: {name}")
-    start_time = time.time()
-    try:
-        cursor = conn.cursor()
-        # Split on semicolon, filter out empty statements
-        statements = [stmt.strip() for stmt in sql.split(';') if stmt.strip()]
-        for stmt in statements:
-            cursor.execute(stmt)
-            conn.commit()  # Commit after each statement
-        cursor.close()
-        elapsed = time.time() - start_time
-        logger.info(f"Completed script: {name} in {elapsed:.2f} seconds")
-    except Exception as e:
-        logger.error(f"Error in script {name}: {str(e)}")
-        raise
+LOG_FILE = r"C:\\LargeFileHolder\\7373\\PreDMSErrorLog_Operations.txt"
 
 def main():
     load_dotenv()
@@ -141,8 +100,13 @@ def main():
                         target_conn.commit()
                         
                 except Exception as e:
-                    logger.error(f"Error executing statements for row {idx} (Justice.{full_table_name}): {e}")
-                    log_exception_to_file(f"Error executing statements for row {idx} (Justice.{full_table_name}): {e}")
+                    logger.error(
+                        f"Error executing statements for row {idx} (Operations.{full_table_name}): {e}"
+                    )
+                    log_exception_to_file(
+                        f"Error executing statements for row {idx} (Operations.{full_table_name}): {e}",
+                        LOG_FILE,
+                    )
 
         cursor.close()
         logger.info("All Drop_IfExists and Select_Into statements executed for Operations Database.")
@@ -167,8 +131,13 @@ def main():
                 cursor.execute(createpk_sql)
                 target_conn.commit()
             except Exception as e:
-                logger.error(f"Error executing statements for row {idx} (Operations.{full_table_name}): {e}")
-                log_exception_to_file(f"Error executing statements for row {idx} (Operations.{full_table_name}): {e}")
+                logger.error(
+                    f"Error executing statements for row {idx} (Operations.{full_table_name}): {e}"
+                )
+                log_exception_to_file(
+                    f"Error executing statements for row {idx} (Operations.{full_table_name}): {e}",
+                    LOG_FILE,
+                )
 
         cursor.close()
         logger.info("All Primary Key/NOT NULL statements executed FOR THE Operations DATABASE.")
@@ -191,7 +160,7 @@ def main():
         logger.exception("Unexpected error")
         import traceback
         error_details = traceback.format_exc()
-        log_exception_to_file(error_details)  # <-- Add this line
+        log_exception_to_file(error_details, LOG_FILE)
         try:
             root = tk.Tk()
             root.withdraw()  # Hide the main window

--- a/03_FinancialDB_Import.py
+++ b/03_FinancialDB_Import.py
@@ -12,58 +12,17 @@ from sqlalchemy.types import Text
 import tkinter as tk
 from tkinter import messagebox
 
+from utils.etl_helpers import (
+    log_exception_to_file,
+    load_sql,
+    run_sql_step,
+    run_sql_script,
+)
+
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
 
-def log_exception_to_file(error_details, log_path=r"C:\LargeFileHolder\7373\PreDMSErrorLog_Financial.txt"):
-    try:
-        with open(log_path, "a", encoding="utf-8") as f:
-            f.write(error_details + "\n")
-    except Exception as file_exc:
-        logger.error(f"Failed to write to error log file: {file_exc}")
-def load_sql(filename):
-    base_dir = os.path.dirname(__file__)
-    sql_path = os.path.join(base_dir, 'sql_scripts', filename)
-    if not os.path.exists(sql_path):
-        logger.error(f"SQL file not found: {sql_path}")
-        raise FileNotFoundError(f"SQL file not found: {sql_path}")
-    with open(sql_path, 'r', encoding='utf-8') as f:
-        return f.read()
-def run_sql_step(conn, name, sql):
-    logger.info(f"Starting step: {name}")
-    start_time = time.time()
-    try:
-        cursor = conn.cursor()
-        cursor.execute(sql)
-        try:
-            results = cursor.fetchall()
-            logger.info(f"{name}: Retrieved {len(results)} rows")
-        except Exception:
-            results = None
-            logger.info(f"{name}: Statement executed (no results to fetch)")
-        cursor.close()
-        elapsed = time.time() - start_time
-        logger.info(f"Completed step: {name} in {elapsed:.2f} seconds")
-        return results
-    except Exception as e:
-        logger.error(f"Error in step {name}: {str(e)}")
-        raise
-def run_sql_script(conn, name, sql):
-    logger.info(f"Starting script: {name}")
-    start_time = time.time()
-    try:
-        cursor = conn.cursor()
-        # Split on semicolon, filter out empty statements
-        statements = [stmt.strip() for stmt in sql.split(';') if stmt.strip()]
-        for stmt in statements:
-            cursor.execute(stmt)
-            conn.commit()  # Commit after each statement
-        cursor.close()
-        elapsed = time.time() - start_time
-        logger.info(f"Completed script: {name} in {elapsed:.2f} seconds")
-    except Exception as e:
-        logger.error(f"Error in script {name}: {str(e)}")
-        raise
+LOG_FILE = r"C:\\LargeFileHolder\\7373\\PreDMSErrorLog_Financial.txt"
 
 def main():
     load_dotenv()
@@ -140,8 +99,13 @@ def main():
                         cursor.execute(select_into_sql)
                         target_conn.commit()
                 except Exception as e:
-                    logger.error(f"Error executing statements for row {idx} (Financial.{full_table_name}): {e}")
-                    log_exception_to_file(f"Error executing statements for row {idx} (Financial.{full_table_name}): {e}")
+                    logger.error(
+                        f"Error executing statements for row {idx} (Financial.{full_table_name}): {e}"
+                    )
+                    log_exception_to_file(
+                        f"Error executing statements for row {idx} (Financial.{full_table_name}): {e}",
+                        LOG_FILE,
+                    )
 
         cursor.close()
         logger.info("All Drop_IfExists and Select_Into statements executed for Financial Database.")
@@ -166,8 +130,13 @@ def main():
                 cursor.execute(createpk_sql)
                 target_conn.commit()
             except Exception as e:
-                logger.error(f"Error executing statements for row {idx} (Financial.{full_table_name}): {e}")
-                log_exception_to_file(f"Error executing statements for row {idx} (Financial.{full_table_name}): {e}")
+                logger.error(
+                    f"Error executing statements for row {idx} (Financial.{full_table_name}): {e}"
+                )
+                log_exception_to_file(
+                    f"Error executing statements for row {idx} (Financial.{full_table_name}): {e}",
+                    LOG_FILE,
+                )
 
         cursor.close()
         logger.info("All Primary Key/NOT NULL statements executed FOR THE Financial DATABASE.")
@@ -190,7 +159,7 @@ def main():
         logger.exception("Unexpected error")
         import traceback
         error_details = traceback.format_exc()
-        log_exception_to_file(error_details)  # <-- Add this line
+        log_exception_to_file(error_details, LOG_FILE)
         try:
             root = tk.Tk()
             root.withdraw()  # Hide the main window

--- a/04_LOBColumns.py
+++ b/04_LOBColumns.py
@@ -12,58 +12,17 @@ from sqlalchemy.types import Text
 import tkinter as tk
 from tkinter import messagebox
 
+from utils.etl_helpers import (
+    log_exception_to_file,
+    load_sql,
+    run_sql_step,
+    run_sql_script,
+)
+
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
 
-def log_exception_to_file(error_details, log_path=r"C:\LargeFileHolder\7373\PreDMSErrorLog_LOBS.txt"):
-    try:
-        with open(log_path, "a", encoding="utf-8") as f:
-            f.write(error_details + "\n")
-    except Exception as file_exc:
-        logger.error(f"Failed to write to error log file: {file_exc}")
-def load_sql(filename):
-    base_dir = os.path.dirname(__file__)
-    sql_path = os.path.join(base_dir, 'sql_scripts', filename)
-    if not os.path.exists(sql_path):
-        logger.error(f"SQL file not found: {sql_path}")
-        raise FileNotFoundError(f"SQL file not found: {sql_path}")
-    with open(sql_path, 'r', encoding='utf-8') as f:
-        return f.read()
-def run_sql_step(conn, name, sql):
-    logger.info(f"Starting step: {name}")
-    start_time = time.time()
-    try:
-        cursor = conn.cursor()
-        cursor.execute(sql)
-        try:
-            results = cursor.fetchall()
-            logger.info(f"{name}: Retrieved {len(results)} rows")
-        except Exception:
-            results = None
-            logger.info(f"{name}: Statement executed (no results to fetch)")
-        cursor.close()
-        elapsed = time.time() - start_time
-        logger.info(f"Completed step: {name} in {elapsed:.2f} seconds")
-        return results
-    except Exception as e:
-        logger.error(f"Error in step {name}: {str(e)}")
-        raise
-def run_sql_script(conn, name, sql):
-    logger.info(f"Starting script: {name}")
-    start_time = time.time()
-    try:
-        cursor = conn.cursor()
-        # Split on semicolon, filter out empty statements
-        statements = [stmt.strip() for stmt in sql.split(';') if stmt.strip()]
-        for stmt in statements:
-            cursor.execute(stmt)
-            conn.commit()  # Commit after each statement
-        cursor.close()
-        elapsed = time.time() - start_time
-        logger.info(f"Completed script: {name} in {elapsed:.2f} seconds")
-    except Exception as e:
-        logger.error(f"Error in script {name}: {str(e)}")
-        raise
+LOG_FILE = r"C:\\LargeFileHolder\\7373\\PreDMSErrorLog_LOBS.txt"
 def get_max_length(conn, schema, table, column, datatype):
     cursor = conn.cursor()
     try:
@@ -173,7 +132,7 @@ def main():
         logger.exception("Unexpected error")
         import traceback
         error_details = traceback.format_exc()
-        log_exception_to_file(error_details)  # <-- Add this line
+        log_exception_to_file(error_details, LOG_FILE)
         try:
             root = tk.Tk()
             root.withdraw()  # Hide the main window

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+# Utility modules for ETL scripts

--- a/utils/etl_helpers.py
+++ b/utils/etl_helpers.py
@@ -1,0 +1,66 @@
+import logging
+import os
+import time
+
+logger = logging.getLogger(__name__)
+
+
+def log_exception_to_file(error_details: str, log_path: str):
+    """Append exception details to a log file."""
+    try:
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(error_details + "\n")
+    except Exception as file_exc:
+        logger.error(f"Failed to write to error log file: {file_exc}")
+
+
+def load_sql(filename: str) -> str:
+    """Load a SQL file from the sql_scripts directory."""
+    base_dir = os.path.dirname(os.path.dirname(__file__)) if '__file__' in globals() else os.getcwd()
+    # The sql_scripts directory lives at the repo root
+    sql_path = os.path.join(base_dir, 'sql_scripts', filename)
+    if not os.path.exists(sql_path):
+        logger.error(f"SQL file not found: {sql_path}")
+        raise FileNotFoundError(f"SQL file not found: {sql_path}")
+    with open(sql_path, 'r', encoding='utf-8') as f:
+        return f.read()
+
+
+def run_sql_step(conn, name: str, sql: str):
+    """Execute a single SQL statement and fetch any results."""
+    logger.info(f"Starting step: {name}")
+    start_time = time.time()
+    try:
+        cursor = conn.cursor()
+        cursor.execute(sql)
+        try:
+            results = cursor.fetchall()
+            logger.info(f"{name}: Retrieved {len(results)} rows")
+        except Exception:
+            results = None
+            logger.info(f"{name}: Statement executed (no results to fetch)")
+        cursor.close()
+        elapsed = time.time() - start_time
+        logger.info(f"Completed step: {name} in {elapsed:.2f} seconds")
+        return results
+    except Exception as e:
+        logger.error(f"Error in step {name}: {str(e)}")
+        raise
+
+
+def run_sql_script(conn, name: str, sql: str):
+    """Execute a multi-statement SQL script."""
+    logger.info(f"Starting script: {name}")
+    start_time = time.time()
+    try:
+        cursor = conn.cursor()
+        statements = [stmt.strip() for stmt in sql.split(';') if stmt.strip()]
+        for stmt in statements:
+            cursor.execute(stmt)
+            conn.commit()
+        cursor.close()
+        elapsed = time.time() - start_time
+        logger.info(f"Completed script: {name} in {elapsed:.2f} seconds")
+    except Exception as e:
+        logger.error(f"Error in script {name}: {str(e)}")
+        raise


### PR DESCRIPTION
## Summary
- centralize shared helper functions in `utils/etl_helpers.py`
- update ETL scripts to import helpers from new module

## Testing
- `python -m py_compile 01_JusticeDB_Import.py 02_OperationsDB_Import.py 03_FinancialDB_Import.py 04_LOBColumns.py utils/etl_helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_68499cc184448323b2068b711b2e13ff