### PR TITLE
Add log path override to ETL scripts

### DIFF
--- a/01_JusticeDB_Import.py
+++ b/01_JusticeDB_Import.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import os
+import argparse
 from dotenv import load_dotenv
 import pandas as pd
 import urllib
@@ -22,11 +23,21 @@ from utils.etl_helpers import (
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
 
-LOG_FILE = r"C:\\LargeFileHolder\\7373\\PreDMSErrorLog_Justice.txt"
+DEFAULT_LOG_FILE = "PreDMSErrorLog_Justice.txt"
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Justice DB Import")
+    parser.add_argument(
+        "--log-file",
+        help="Path to the error log file. Overrides the EJ_LOG_DIR environment variable.",
+    )
+    return parser.parse_args()
 
 def main():
+    args = parse_args()
     load_dotenv()
     include_empty = os.environ.get("INCLUDE_EMPTY_TABLES", "0") == "1"
+    log_file = args.log_file or os.path.join(os.environ.get("EJ_LOG_DIR", ""), DEFAULT_LOG_FILE)
     target_conn = None
 
     try:
@@ -115,7 +126,7 @@ def main():
                     logger.error(f"Error executing statements for row {idx} (Justice.{full_table_name}): {e}")
                     log_exception_to_file(
                         f"Error executing statements for row {idx} (Justice.{full_table_name}): {e}",
-                        LOG_FILE,
+                        log_file,
                     )
 
         cursor.close()
@@ -145,7 +156,7 @@ def main():
                 logger.error(f"Error executing PK statements for row {idx} (Justice.{full_table_name}): {e}")
                 log_exception_to_file(
                     f"Error executing PK statements for row {idx} (Justice.{full_table_name}): {e}",
-                    LOG_FILE,
+                    log_file,
                 )
 
         cursor.close()
@@ -170,7 +181,7 @@ def main():
         logger.exception("Unexpected error")
         import traceback
         error_details = traceback.format_exc()
-        log_exception_to_file(error_details, LOG_FILE)
+        log_exception_to_file(error_details, log_file)
         try:
             root = tk.Tk()
             root.withdraw()  # Hide the main window

--- a/03_FinancialDB_Import.py
+++ b/03_FinancialDB_Import.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import os
+import argparse
 from dotenv import load_dotenv
 import pandas as pd
 import urllib
@@ -22,11 +23,21 @@ from utils.etl_helpers import (
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
 
-LOG_FILE = r"C:\\LargeFileHolder\\7373\\PreDMSErrorLog_Financial.txt"
+DEFAULT_LOG_FILE = "PreDMSErrorLog_Financial.txt"
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Financial DB Import")
+    parser.add_argument(
+        "--log-file",
+        help="Path to the error log file. Overrides the EJ_LOG_DIR environment variable.",
+    )
+    return parser.parse_args()
 
 def main():
+    args = parse_args()
     load_dotenv()
     include_empty = os.environ.get("INCLUDE_EMPTY_TABLES", "0") == "1"
+    log_file = args.log_file or os.path.join(os.environ.get("EJ_LOG_DIR", ""), DEFAULT_LOG_FILE)
     target_conn = get_target_connection()
 
     try:
@@ -104,7 +115,7 @@ def main():
                     )
                     log_exception_to_file(
                         f"Error executing statements for row {idx} (Financial.{full_table_name}): {e}",
-                        LOG_FILE,
+                        log_file,
                     )
 
         cursor.close()
@@ -135,7 +146,7 @@ def main():
                 )
                 log_exception_to_file(
                     f"Error executing statements for row {idx} (Financial.{full_table_name}): {e}",
-                    LOG_FILE,
+                    log_file,
                 )
 
         cursor.close()
@@ -159,7 +170,7 @@ def main():
         logger.exception("Unexpected error")
         import traceback
         error_details = traceback.format_exc()
-        log_exception_to_file(error_details, LOG_FILE)
+        log_exception_to_file(error_details, log_file)
         try:
             root = tk.Tk()
             root.withdraw()  # Hide the main window

--- a/04_LOBColumns.py
+++ b/04_LOBColumns.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import os
+import argparse
 from dotenv import load_dotenv
 import pandas as pd
 import urllib
@@ -22,7 +23,15 @@ from utils.etl_helpers import (
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
 
-LOG_FILE = r"C:\\LargeFileHolder\\7373\\PreDMSErrorLog_LOBS.txt"
+DEFAULT_LOG_FILE = "PreDMSErrorLog_LOBS.txt"
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="LOB Column Processing")
+    parser.add_argument(
+        "--log-file",
+        help="Path to the error log file. Overrides the EJ_LOG_DIR environment variable.",
+    )
+    return parser.parse_args()
 def get_max_length(conn, schema, table, column, datatype):
     cursor = conn.cursor()
     try:
@@ -50,8 +59,10 @@ def build_alter_column_sql(schema, table, column, datatype, max_length):
         return f"ALTER TABLE [{schema}].[{table}] ALTER COLUMN [{column}] VARCHAR({max_length}) NULL"
 
 def main():
+    args = parse_args()
     load_dotenv()
     include_empty = os.environ.get("INCLUDE_EMPTY_TABLES", "0") == "1"
+    log_file = args.log_file or os.path.join(os.environ.get("EJ_LOG_DIR", ""), DEFAULT_LOG_FILE)
     target_conn = get_target_connection()
 
     try:
@@ -132,7 +143,7 @@ def main():
         logger.exception("Unexpected error")
         import traceback
         error_details = traceback.format_exc()
-        log_exception_to_file(error_details, LOG_FILE)
+        log_exception_to_file(error_details, log_file)
         try:
             root = tk.Tk()
             root.withdraw()  # Hide the main window

--- a/README.md
+++ b/README.md
@@ -36,3 +36,8 @@ Each script expects SQL files located in the `sql_scripts/` directory and
 relies on `MSSQL_TARGET_CONN_STR` for the target connection string. When a CSV
 directory is selected, the path is exported via the `EJ_CSV_DIR` environment
 variable so the ETL scripts can locate their input files.
+
+Error details are written to log files. By default the logs are created in the
+current working directory with names like `PreDMSErrorLog_Justice.txt`. Set the
+`EJ_LOG_DIR` environment variable to override the directory or pass a full path
+using the `--log-file` argument when running an individual script.


### PR DESCRIPTION
## Summary
- allow specifying log directory via `EJ_LOG_DIR` or `--log-file`
- document log configuration in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68499f8770808323a53d4ec7e5e47148