### PR TITLE
Remove unused ClientError imports

### DIFF
--- a/01_JusticeDB_Import.py
+++ b/01_JusticeDB_Import.py
@@ -7,7 +7,6 @@ import pandas as pd
 import urllib
 import sqlalchemy
 from db.mssql import get_target_connection
-from botocore.exceptions import ClientError
 from tqdm import tqdm
 from sqlalchemy.types import Text
 import tkinter as tk
@@ -177,7 +176,7 @@ def main():
             return
 
 
-    except (ClientError, Exception) as e:
+    except Exception as e:
         logger.exception("Unexpected error")
         import traceback
         error_details = traceback.format_exc()

--- a/02_OperationsDB_Import.py
+++ b/02_OperationsDB_Import.py
@@ -7,7 +7,6 @@ import pandas as pd
 import urllib
 import sqlalchemy
 from db.mssql import get_target_connection
-from botocore.exceptions import ClientError
 from tqdm import tqdm
 from sqlalchemy.types import Text
 import tkinter as tk
@@ -167,7 +166,7 @@ def main():
                 target_conn.close()
             return
 
-    except (ClientError, Exception) as e:
+    except Exception as e:
         logger.exception("Unexpected error")
         import traceback
         error_details = traceback.format_exc()

--- a/03_FinancialDB_Import.py
+++ b/03_FinancialDB_Import.py
@@ -7,7 +7,6 @@ import pandas as pd
 import urllib
 import sqlalchemy
 from db.mssql import get_target_connection
-from botocore.exceptions import ClientError
 from tqdm import tqdm
 from sqlalchemy.types import Text
 import tkinter as tk
@@ -166,7 +165,7 @@ def main():
                 target_conn.close()
             return
 
-    except (ClientError, Exception) as e:
+    except Exception as e:
         logger.exception("Unexpected error")
         import traceback
         error_details = traceback.format_exc()

--- a/04_LOBColumns.py
+++ b/04_LOBColumns.py
@@ -7,7 +7,6 @@ import pandas as pd
 import urllib
 import sqlalchemy
 from db.mssql import get_target_connection
-from botocore.exceptions import ClientError
 from tqdm import tqdm
 from sqlalchemy.types import Text
 import tkinter as tk
@@ -139,7 +138,7 @@ def main():
                     logger.error(f"Failed to alter column: {e}")
                     raise
 
-    except (ClientError, Exception) as e:
+    except Exception as e:
         logger.exception("Unexpected error")
         import traceback
         error_details = traceback.format_exc()


### PR DESCRIPTION
## Summary
- clean up ETL scripts by removing unused `ClientError` imports
- update exception handling to catch general `Exception`

## Testing
- `python -m py_compile 01_JusticeDB_Import.py 02_OperationsDB_Import.py 03_FinancialDB_Import.py 04_LOBColumns.py`

------
https://chatgpt.com/codex/tasks/task_e_6849a0c801788323a19f657457693f0e