### PR TITLE
Fix dotenv initialization

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -1,6 +1,8 @@
 from dotenv import load_dotenv
 import os
 
+# Load environment variables from a .env file if present. This only needs to
+# happen once so we do it at import time before reading any variables.
 load_dotenv()
 
 MSSQL_SOURCE_CONN_STR = os.getenv("MSSQL_SOURCE_CONN_STR")
@@ -11,6 +13,4 @@ MYSQL_CONN_DICT = {
     'password': os.getenv("MYSQL_PASSWORD"),
     'database': os.getenv("MYSQL_DATABASE"),
 }
-
-load_dotenv()
 


### PR DESCRIPTION
## Summary
- clean up `load_dotenv()` usage in settings

## Testing
- `python -m py_compile config/settings.py`
- `pip install python-dotenv` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6849af683a6c83239460034c270f2c95