### PR TITLE
Add MIT license and baseline tests

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tests/test_mssql.py
+++ b/tests/test_mssql.py
@@ -1,0 +1,29 @@
+import sys, types
+if "mysql" not in sys.modules:
+    dummy_mysql = types.ModuleType("mysql")
+    dummy_mysql.connector = types.SimpleNamespace(connect=lambda **k: None)
+    sys.modules["mysql"] = dummy_mysql
+    sys.modules["mysql.connector"] = dummy_mysql.connector
+if "dotenv" not in sys.modules:
+    mod=types.ModuleType("dotenv")
+    mod.load_dotenv=lambda *a, **k: None
+    sys.modules["dotenv"] = mod
+if "pyodbc" not in sys.modules:
+    sys.modules["pyodbc"] = types.SimpleNamespace(connect=lambda *a, **k: None)
+import db.mssql as mssql
+
+class DummyConn:
+    pass
+
+def test_get_target_connection(monkeypatch):
+    conn_str = 'DRIVER=SQL;SERVER=server;DATABASE=db;'
+
+    def fake_connect(arg):
+        assert arg == conn_str
+        return DummyConn()
+
+    monkeypatch.setattr(mssql, 'MSSQL_TARGET_CONN_STR', conn_str)
+    monkeypatch.setattr(mssql.pyodbc, 'connect', fake_connect)
+
+    conn = mssql.get_target_connection()
+    assert isinstance(conn, DummyConn)

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -1,0 +1,53 @@
+import sys, types
+if "dotenv" not in sys.modules:
+    mod=types.ModuleType("dotenv")
+    mod.load_dotenv=lambda *a, **k: None
+    sys.modules["dotenv"] = mod
+if "pyodbc" not in sys.modules:
+    sys.modules["pyodbc"] = types.SimpleNamespace(connect=lambda *a, **k: None)
+if "mysql" not in sys.modules:
+    dummy_mysql = types.ModuleType("mysql")
+    dummy_mysql.connector = types.SimpleNamespace(connect=lambda **k: None)
+    sys.modules["mysql"] = dummy_mysql
+    sys.modules["mysql.connector"] = dummy_mysql.connector
+
+import pytest
+
+import db.mysql as mysql
+
+class DummyConn:
+    pass
+
+def test_get_mysql_connection_env(monkeypatch):
+    monkeypatch.setenv('MYSQL_HOST', 'localhost')
+    monkeypatch.setenv('MYSQL_USER', 'user')
+    monkeypatch.setenv('MYSQL_PASSWORD', 'pass')
+    monkeypatch.setenv('MYSQL_DATABASE', 'db')
+    monkeypatch.setenv('MYSQL_PORT', '3307')
+
+    called = {}
+    def fake_connect(**kwargs):
+        called['kwargs'] = kwargs
+        return DummyConn()
+
+    monkeypatch.setattr(mysql.mysql.connector, 'connect', fake_connect)
+
+    conn = mysql.get_mysql_connection()
+    assert isinstance(conn, DummyConn)
+    assert called['kwargs'] == {
+        'host': 'localhost',
+        'user': 'user',
+        'password': 'pass',
+        'database': 'db',
+        'port': 3307,
+    }
+
+
+def test_get_mysql_connection_missing(monkeypatch):
+    monkeypatch.delenv('MYSQL_HOST', raising=False)
+    monkeypatch.delenv('MYSQL_USER', raising=False)
+    monkeypatch.delenv('MYSQL_PASSWORD', raising=False)
+    monkeypatch.delenv('MYSQL_DATABASE', raising=False)
+
+    with pytest.raises(ValueError):
+        mysql.get_mysql_connection()


### PR DESCRIPTION
## Summary
- add MIT license file
- create unit tests for MySQL and MSSQL connection helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b00722448323830550e744bdf714