### PR TITLE
Make target database configurable

### DIFF
--- a/03_FinancialDB_Import.py
+++ b/03_FinancialDB_Import.py
@@ -12,6 +12,7 @@ from tqdm import tqdm
 from sqlalchemy.types import Text
 import tkinter as tk
 from tkinter import messagebox
+from config import settings
 
 from utils.etl_helpers import (
     log_exception_to_file,
@@ -24,6 +25,9 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
 
 DEFAULT_LOG_FILE = "PreDMSErrorLog_Financial.txt"
+
+# Target database name derived from environment or connection string
+DB_NAME = settings.MSSQL_TARGET_DB_NAME or settings._parse_database_name(settings.MSSQL_TARGET_CONN_STR)
 
 def parse_args():
     """Parse command line arguments for the Financial DB import script."""
@@ -117,14 +121,14 @@ def load_config(config_file=None):
 def gather_fee_instance_ids(conn, config):
     """Gather list of FeeInstanceIDs that are in scope for supervision."""
     logger.info("Gathering list of FeeInstanceIDs that are in Scope for Supervision.")
-    gather_feeinstances_sql = load_sql('financial/gather_feeinstanceids.sql')
+    gather_feeinstances_sql = load_sql('financial/gather_feeinstanceids.sql', DB_NAME)
     run_sql_script(conn, 'gather_feeinstanceids', gather_feeinstances_sql, timeout=config['sql_timeout'])
     logger.info("Fee Instance IDs gathered successfully.")
 
 def prepare_drop_and_select(conn, config):
     """Prepare SQL statements for dropping and selecting data."""
     logger.info("Gathering list of Financial tables with SQL Commands to be migrated.")
-    additional_sql = load_sql('financial/gather_drops_and_selects_financial.sql')
+    additional_sql = load_sql('financial/gather_drops_and_selects_financial.sql', DB_NAME)
     run_sql_script(
         conn, 
         'gather_drops_and_selects_Financial', 
@@ -178,7 +182,7 @@ def import_joins(config, log_file):
 def update_joins_in_tables(conn, config):
     """Update the TablesToConvert_Financial table with JOINs."""
     logger.info("Updating JOINS in TablesToConvert_Financial List")
-    update_joins_sql = load_sql('financial/update_joins_financial.sql')
+    update_joins_sql = load_sql('financial/update_joins_financial.sql', DB_NAME)
     run_sql_script(conn, 'update_joins_Financial', update_joins_sql, timeout=config['sql_timeout'])
     logger.info("Updating JOINS for Financial tables is complete.")
 
@@ -187,11 +191,11 @@ def execute_table_operations(conn, config, log_file):
     logger.info("Executing table operations (DROP/SELECT)")
     
     cursor = conn.cursor()
-    cursor.execute("""
-        SELECT RowID, DatabaseName, SchemaName, TableName, fConvert, ScopeRowCount, 
-               Drop_IfExists, CAST(Select_Into AS VARCHAR(MAX)) + Joins AS [Select_Into] 
-        FROM ELPaso_TX.dbo.TablesToConvert_Financial S 
-        WHERE fConvert=1 
+    cursor.execute(f"""
+        SELECT RowID, DatabaseName, SchemaName, TableName, fConvert, ScopeRowCount,
+               Drop_IfExists, CAST(Select_Into AS VARCHAR(MAX)) + Joins AS [Select_Into]
+        FROM {DB_NAME}.dbo.TablesToConvert_Financial S
+        WHERE fConvert=1
         ORDER BY DatabaseName, SchemaName, TableName
     """)
     rows = cursor.fetchall()
@@ -236,26 +240,26 @@ def create_primary_keys(conn, config, log_file):
         return
     
     logger.info("Generating List of Primary Keys and NOT NULL Columns for Financial Database")
-    pk_sql = load_sql('financial/create_primarykeys_financial.sql')
+    pk_sql = load_sql('financial/create_primarykeys_financial.sql', DB_NAME)
     run_sql_script(conn, 'create_primarykeys_Financial', pk_sql, timeout=config['sql_timeout'])
     
     cursor = conn.cursor()
-    cursor.execute("""
+    cursor.execute(f"""
         WITH CTE_PKS AS (
-            SELECT 1 AS TYPEY, S.DatabaseName, S.SchemaName, S.TableName, S.Script 
-            FROM ELPaso_TX.dbo.PrimaryKeyScripts_Financial S 
-            WHERE S.ScriptType='NOT_NULL' 
-            UNION 
-            SELECT 2 AS TYPEY, S.DatabaseName, S.SchemaName, S.TableName, S.Script 
-            FROM ELPaso_TX.dbo.PrimaryKeyScripts_Financial S 
+            SELECT 1 AS TYPEY, S.DatabaseName, S.SchemaName, S.TableName, S.Script
+            FROM {DB_NAME}.dbo.PrimaryKeyScripts_Financial S
+            WHERE S.ScriptType='NOT_NULL'
+            UNION
+            SELECT 2 AS TYPEY, S.DatabaseName, S.SchemaName, S.TableName, S.Script
+            FROM {DB_NAME}.dbo.PrimaryKeyScripts_Financial S
             WHERE S.ScriptType='PK'
-        ) 
-        SELECT S.TYPEY, S.DatabaseName, S.SchemaName, S.TableName, 
-               REPLACE(S.Script, 'FLAG NOT NULL', 'BIT NOT NULL') AS [Script], TTC.fConvert 
-        FROM CTE_PKS S 
-        INNER JOIN ELPaso_TX.dbo.TablesToConvert_Financial TTC WITH (NOLOCK) 
-            ON S.SCHEMANAME=TTC.SchemaName AND S.TABLENAME=TTC.TableName 
-        WHERE TTC.fConvert=1 
+        )
+        SELECT S.TYPEY, S.DatabaseName, S.SchemaName, S.TableName,
+               REPLACE(S.Script, 'FLAG NOT NULL', 'BIT NOT NULL') AS [Script], TTC.fConvert
+        FROM CTE_PKS S
+        INNER JOIN {DB_NAME}.dbo.TablesToConvert_Financial TTC WITH (NOLOCK)
+            ON S.SCHEMANAME=TTC.SchemaName AND S.TABLENAME=TTC.TableName
+        WHERE TTC.fConvert=1
         ORDER BY S.SCHEMANAME, S.TABLENAME, S.TYPEY
     """)
     rows = cursor.fetchall()

--- a/config/settings.py
+++ b/config/settings.py
@@ -7,6 +7,20 @@ load_dotenv()
 
 MSSQL_SOURCE_CONN_STR = os.getenv("MSSQL_SOURCE_CONN_STR")
 MSSQL_TARGET_CONN_STR = os.getenv("MSSQL_TARGET_CONN_STR")
+
+# Utility to pull the database name out of a connection string like
+# "DRIVER=...;SERVER=...;DATABASE=MyDB;UID=user;PWD=pass".
+def _parse_database_name(conn_str: str) -> str | None:
+    if not conn_str:
+        return None
+    for part in conn_str.split(';'):
+        if part.lower().startswith('database='):
+            return part.split('=', 1)[1]
+    return None
+
+# Allow overriding the target database name explicitly or derive it from the
+# connection string provided by the user.
+MSSQL_TARGET_DB_NAME = os.getenv("MSSQL_TARGET_DB_NAME") or _parse_database_name(MSSQL_TARGET_CONN_STR)
 MYSQL_CONN_DICT = {
     'host': os.getenv("MYSQL_HOST"),
     'user': os.getenv("MYSQL_USER"),

--- a/run_etl.py
+++ b/run_etl.py
@@ -104,6 +104,9 @@ class App(tk.Tk):
         messagebox.showinfo("Success", "Connection successful!")
         self.conn_str = conn_str
         os.environ["MSSQL_TARGET_CONN_STR"] = conn_str
+        db_name = self.entries["database"].get()
+        if db_name:
+            os.environ["MSSQL_TARGET_DB_NAME"] = db_name
         self.csv_dir = self.csv_dir_var.get()
         if self.csv_dir:
             os.environ["EJ_CSV_DIR"] = self.csv_dir

--- a/utils/etl_helpers.py
+++ b/utils/etl_helpers.py
@@ -12,8 +12,13 @@ def log_exception_to_file(error_details: str, log_path: str):
             f.write(error_details + "\n")
     except Exception as file_exc:
         logger.error(f"Failed to write to error log file: {file_exc}")
-def load_sql(filename: str) -> str:
-    """Load a SQL file from the sql_scripts directory."""
+def load_sql(filename: str, db_name: str | None = None) -> str:
+    """Load a SQL file from the sql_scripts directory.
+
+    If ``db_name`` is provided, occurrences of the hard coded ``ELPaso_TX``
+    database name are replaced with the supplied value so the scripts can run
+    against any target database.
+    """
     base_dir = os.path.dirname(os.path.dirname(__file__)) if '__file__' in globals() else os.getcwd()
     # The sql_scripts directory lives at the repo root
     sql_path = os.path.join(base_dir, 'sql_scripts', filename)
@@ -21,7 +26,10 @@ def load_sql(filename: str) -> str:
         logger.error(f"SQL file not found: {sql_path}")
         raise FileNotFoundError(f"SQL file not found: {sql_path}")
     with open(sql_path, 'r', encoding='utf-8') as f:
-        return f.read()
+        sql = f.read()
+    if db_name:
+        sql = sql.replace('ELPaso_TX', db_name).replace('ElPaso_TX', db_name)
+    return sql
 def run_sql_step(conn, name: str, sql: str):
     """Execute a single SQL statement and fetch any results."""
     logger.info(f"Starting step: {name}")


### PR DESCRIPTION
## Summary
- parse DB name from connection string
- allow `load_sql` to replace `ELPaso_TX` in SQL files
- wire database name from GUI into environment
- use the configured DB name when executing SQL scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849bc623880832382d3ee8ff5468cb4