### PR TITLE
Improve ETL error handling

### DIFF
--- a/tests/test_etl_helpers.py
+++ b/tests/test_etl_helpers.py
@@ -1,0 +1,51 @@
+import pytest
+
+from utils.etl_helpers import run_sql_step, run_sql_script, SQLExecutionError
+
+class DummyCursor:
+    def __init__(self, fail=False, fail_sql=None):
+        self.fail = fail
+        self.fail_sql = fail_sql
+    def execute(self, sql, params=None):
+        if 'SET LOCK_TIMEOUT' in sql:
+            return
+        if self.fail or (self.fail_sql and sql.strip() == self.fail_sql):
+            raise RuntimeError('boom')
+    def fetchall(self):
+        return [('row',)]
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+class DummyConn:
+    def __init__(self, fail=False, fail_sql=None):
+        self.fail = fail
+        self.fail_sql = fail_sql
+    def cursor(self):
+        return DummyCursor(self.fail, self.fail_sql)
+    def commit(self):
+        pass
+
+
+def test_run_sql_step_success():
+    conn = DummyConn()
+    result = run_sql_step(conn, 'test', 'SELECT 1')
+    assert result == [('row',)]
+
+
+def test_run_sql_step_failure():
+    conn = DummyConn(fail=True)
+    with pytest.raises(SQLExecutionError) as exc:
+        run_sql_step(conn, 'table', 'SELECT 1')
+    assert exc.value.sql == 'SELECT 1'
+    assert exc.value.table_name == 'table'
+
+
+def test_run_sql_script_failure():
+    sql = 'SELECT 1; FAIL; SELECT 2'
+    conn = DummyConn(fail_sql='FAIL')
+    with pytest.raises(SQLExecutionError) as exc:
+        run_sql_script(conn, 'table', sql)
+    assert exc.value.sql.strip() == 'FAIL'
+    assert exc.value.table_name == 'table'

--- a/utils/etl_helpers.py
+++ b/utils/etl_helpers.py
@@ -3,6 +3,20 @@ import os
 import time
 from typing import Optional, Any, List
 
+class ETLError(Exception):
+    """Base exception for ETL operations."""
+
+
+class SQLExecutionError(ETLError):
+    """Exception raised when SQL execution fails."""
+
+    def __init__(self, sql: str, original_error: Exception, table_name: Optional[str] = None):
+        self.sql = sql
+        self.original_error = original_error
+        self.table_name = table_name
+        msg = f"SQL execution failed for {table_name or 'statement'}: {original_error}"
+        super().__init__(msg)
+
 logger = logging.getLogger(__name__)
 
 
@@ -74,8 +88,8 @@ def run_sql_step(conn, name: str, sql: str, timeout: int = 300) -> Optional[List
         logger.info(f"Completed step: {name} in {elapsed:.2f} seconds")
         return results
     except Exception as e:
-        logger.error(f"Error in step {name}: {str(e)}")
-        raise
+        logger.error(f"Error executing step {name}: {e}. SQL: {sql}")
+        raise SQLExecutionError(sql, e, table_name=name)
 def run_sql_script(conn, name: str, sql: str, timeout: int = 300):
     """Execute a multi-statement SQL script.
     
@@ -102,15 +116,23 @@ def run_sql_script(conn, name: str, sql: str, timeout: int = 300):
                 for stmt in statements:
                     # Skip comments and empty statements
                     if stmt and not stmt.strip().startswith('--'):
-                        cursor.execute(stmt)
-                        conn.commit()
-                        total_statements += 1
+                        try:
+                            cursor.execute(stmt)
+                            conn.commit()
+                            total_statements += 1
+                        except Exception as e:
+                            logger.error(f"Error executing script {name}: {e}. SQL: {stmt}")
+                            raise SQLExecutionError(stmt, e, table_name=name)
 
         elapsed = time.time() - start_time
-        logger.info(f"Completed script: {name} - executed {total_statements} statements in {elapsed:.2f} seconds")
-    except Exception as e:
-        logger.error(f"Error in script {name}: {str(e)}")
+        logger.info(
+            f"Completed script: {name} - executed {total_statements} statements in {elapsed:.2f} seconds"
+        )
+    except SQLExecutionError:
         raise
+    except Exception as e:
+        logger.error(f"Error in script {name}: {e}")
+        raise SQLExecutionError(sql, e, table_name=name)
 def execute_sql_with_timeout(conn, sql: str, params: Optional[tuple] = None, timeout: int = 300) -> Any:
     """Execute SQL with parameters and timeout.
     
@@ -134,5 +156,6 @@ def execute_sql_with_timeout(conn, sql: str, params: Optional[tuple] = None, tim
                 cursor.execute(sql)
 
             return cursor
-        except Exception:
-            raise
+        except Exception as e:
+            logger.error(f"Error executing SQL: {e}. SQL: {sql}")
+            raise SQLExecutionError(sql, e)


### PR DESCRIPTION
## Summary
- add ETLError and SQLExecutionError
- wrap SQL execution helpers with these custom exceptions
- log SQL text when failures occur
- test new exception behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c6fba0748832399cfdf820d69697b