### PR TITLE
Add SQL retry helper

### DIFF
--- a/04_LOBColumns.py
+++ b/04_LOBColumns.py
@@ -18,7 +18,7 @@ from config import settings
 from utils.etl_helpers import (
     log_exception_to_file,
     load_sql,
-    run_sql_step,
+    run_sql_step_with_retry,
     run_sql_script,
 )
 
@@ -250,7 +250,12 @@ def execute_lob_column_updates(conn, config, log_file):
 
             if alter_sql:
                 try:
-                    run_sql_step(conn, f"Alter Column {idx}", alter_sql, timeout=config['sql_timeout'])
+                    run_sql_step_with_retry(
+                        conn,
+                        f"Alter Column {idx}",
+                        alter_sql,
+                        timeout=config['sql_timeout'],
+                    )
                     conn.commit()
                 except Exception as e:
                     error_msg = f"Failed to alter column (statement {idx}): {e}"

--- a/tests/test_etl_helpers.py
+++ b/tests/test_etl_helpers.py
@@ -1,16 +1,36 @@
 import pytest
+import sys, types
 
-from utils.etl_helpers import run_sql_step, run_sql_script, SQLExecutionError
+if "pyodbc" not in sys.modules:
+    class _DummyError(Exception):
+        pass
+    sys.modules["pyodbc"] = types.SimpleNamespace(
+        Error=_DummyError, connect=lambda *a, **k: None
+    )
+
+from utils.etl_helpers import (
+    run_sql_step,
+    run_sql_script,
+    run_sql_step_with_retry,
+    SQLExecutionError,
+)
 
 class DummyCursor:
-    def __init__(self, fail=False, fail_sql=None):
+    def __init__(self, fail=False, fail_sql=None, conn=None):
         self.fail = fail
         self.fail_sql = fail_sql
+        self.conn = conn
     def execute(self, sql, params=None):
         if 'SET LOCK_TIMEOUT' in sql:
             return
-        if self.fail or (self.fail_sql and sql.strip() == self.fail_sql):
-            raise RuntimeError('boom')
+        if (
+            self.fail
+            or (self.fail_sql and sql.strip() == self.fail_sql)
+            or (self.conn and self.conn.fail_times > 0)
+        ):
+            if self.conn and self.conn.fail_times > 0:
+                self.conn.fail_times -= 1
+            raise sys.modules["pyodbc"].Error("boom")
     def fetchall(self):
         return [('row',)]
     def __enter__(self):
@@ -19,11 +39,13 @@ class DummyCursor:
         pass
 
 class DummyConn:
-    def __init__(self, fail=False, fail_sql=None):
+    def __init__(self, fail=False, fail_sql=None, fail_times=0):
         self.fail = fail
         self.fail_sql = fail_sql
+        self.fail_times = fail_times
+
     def cursor(self):
-        return DummyCursor(self.fail, self.fail_sql)
+        return DummyCursor(self.fail, self.fail_sql, conn=self)
     def commit(self):
         pass
 
@@ -49,3 +71,15 @@ def test_run_sql_script_failure():
         run_sql_script(conn, 'table', sql)
     assert exc.value.sql.strip() == 'FAIL'
     assert exc.value.table_name == 'table'
+
+
+def test_run_sql_step_with_retry_success():
+    conn = DummyConn()
+    result = run_sql_step_with_retry(conn, 'test', 'SELECT 1')
+    assert result == [('row',)]
+
+
+def test_run_sql_step_with_retry_retries(monkeypatch):
+    conn = DummyConn(fail_times=2)
+    result = run_sql_step_with_retry(conn, 'test', 'SELECT 1', max_retries=3)
+    assert result == [('row',)]


### PR DESCRIPTION
## Summary
- implement `run_sql_step_with_retry` with exponential backoff
- use retry helper in table operations, PK creation, and LOB processing
- expand tests for retry logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7651cff08323b60ed986d4804f5f