### PR TITLE
Introduce ETLConstants class

### DIFF
--- a/04_LOBColumns.py
+++ b/04_LOBColumns.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 from sqlalchemy.types import Text
 import tkinter as tk
 from tkinter import messagebox
-from config import settings
+from config import settings, ETLConstants
 
 from utils.etl_helpers import (
     log_exception_to_file,
@@ -92,8 +92,8 @@ def load_config(config_file=None):
     config = {
         "include_empty_tables": False,
         "log_filename": DEFAULT_LOG_FILE,
-        "sql_timeout": 300,  # seconds
-        "batch_size": 100,
+        "sql_timeout": ETLConstants.DEFAULT_SQL_TIMEOUT,  # seconds
+        "batch_size": ETLConstants.DEFAULT_BULK_INSERT_BATCH_SIZE,
     }
     
     if config_file and os.path.exists(config_file):
@@ -107,7 +107,14 @@ def load_config(config_file=None):
     
     return config
 
-def get_max_length(conn, schema, table, column, datatype, timeout=300):
+def get_max_length(
+    conn,
+    schema,
+    table,
+    column,
+    datatype,
+    timeout=ETLConstants.DEFAULT_SQL_TIMEOUT,
+):
     """Determine the maximum length needed for a text/varchar column."""
     with conn.cursor() as cursor:
         try:
@@ -172,7 +179,9 @@ def gather_lob_columns(conn, config, log_file):
 
         columns = [desc[0] for desc in cursor.description]
 
-        batch_size = config.get('batch_size', 100)
+        batch_size = config.get(
+            'batch_size', ETLConstants.DEFAULT_BULK_INSERT_BATCH_SIZE
+        )
         processed = 0
         progress = tqdm(desc="Analyzing LOB Columns", unit="column")
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -4,10 +4,12 @@ from .settings import (
     MSSQL_SOURCE_CONN_STR,
     MSSQL_TARGET_CONN_STR,
     MYSQL_CONN_DICT,
+    ETLConstants,
 )
 
 __all__ = [
     "MSSQL_SOURCE_CONN_STR",
     "MSSQL_TARGET_CONN_STR",
     "MYSQL_CONN_DICT",
+    "ETLConstants",
 ]

--- a/config/settings.py
+++ b/config/settings.py
@@ -30,3 +30,19 @@ MYSQL_CONN_DICT = {
     'database': os.getenv("MYSQL_DATABASE"),
 }
 
+
+class ETLConstants:
+    """Default values used across the ETL pipeline."""
+
+    #: Default timeout for SQL statements in seconds
+    DEFAULT_SQL_TIMEOUT = 300
+
+    #: Default number of rows to insert per batch when doing bulk inserts
+    DEFAULT_BULK_INSERT_BATCH_SIZE = 100
+
+    #: Maximum number of retry attempts for transient failures
+    MAX_RETRY_ATTEMPTS = 3
+
+    #: Default connection timeout when establishing database connections
+    CONNECTION_TIMEOUT = 30
+

--- a/etl/base_importer.py
+++ b/etl/base_importer.py
@@ -23,6 +23,7 @@ from etl.core import (
     validate_environment,
     validate_sql_identifier,
 )
+from config import ETLConstants
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +66,7 @@ class BaseDBImporter:
             "csv_filename": self.DEFAULT_CSV_FILE,
             "log_filename": self.DEFAULT_LOG_FILE,
             "skip_pk_creation": False,
-            "sql_timeout": 300,  # seconds
+            "sql_timeout": ETLConstants.DEFAULT_SQL_TIMEOUT,  # seconds
         }
         
         self.config = load_config(args.config_file, default_config)

--- a/etl/core.py
+++ b/etl/core.py
@@ -6,6 +6,7 @@ import re
 import unicodedata
 from dataclasses import dataclass, field
 from tqdm import tqdm
+from config import ETLConstants
 
 _IDENTIFIER_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
 
@@ -25,7 +26,11 @@ class Settings:
     ej_csv_dir: str = field(default_factory=lambda: os.getenv("EJ_CSV_DIR"))
     ej_log_dir: str = field(default_factory=lambda: os.getenv("EJ_LOG_DIR", os.getcwd()))
     include_empty_tables: bool = field(default_factory=lambda: os.getenv("INCLUDE_EMPTY_TABLES", "0") == "1")
-    sql_timeout: int = field(default_factory=lambda: int(os.getenv("SQL_TIMEOUT", "300")))
+    sql_timeout: int = field(
+        default_factory=lambda: int(
+            os.getenv("SQL_TIMEOUT", str(ETLConstants.DEFAULT_SQL_TIMEOUT))
+        )
+    )
 
     def __post_init__(self) -> None:
         missing = []

--- a/tests/test_etl_helpers.py
+++ b/tests/test_etl_helpers.py
@@ -8,6 +8,12 @@ if "pyodbc" not in sys.modules:
         Error=_DummyError, connect=lambda *a, **k: None
     )
 
+if "dotenv" not in sys.modules:
+    mod = types.ModuleType("dotenv")
+    mod.load_dotenv = lambda *a, **k: None
+    sys.modules["dotenv"] = mod
+
+from config import ETLConstants
 from utils.etl_helpers import (
     run_sql_step,
     run_sql_script,
@@ -81,5 +87,7 @@ def test_run_sql_step_with_retry_success():
 
 def test_run_sql_step_with_retry_retries(monkeypatch):
     conn = DummyConn(fail_times=2)
-    result = run_sql_step_with_retry(conn, 'test', 'SELECT 1', max_retries=3)
+    result = run_sql_step_with_retry(
+        conn, 'test', 'SELECT 1', max_retries=ETLConstants.MAX_RETRY_ATTEMPTS
+    )
     assert result == [('row',)]

--- a/utils/etl_helpers.py
+++ b/utils/etl_helpers.py
@@ -4,8 +4,7 @@ import os
 import time
 from typing import Optional, Any, List
 
-# Maximum number of attempts for retryable SQL operations
-MAX_RETRY_ATTEMPTS = 3
+from config import ETLConstants
 
 class ETLError(Exception):
     """Base exception for ETL operations."""
@@ -61,7 +60,9 @@ def load_sql(filename: str, db_name: Optional[str] = None) -> str:
         logger.debug(f"Replaced database name in {filename} with {db_name}")
     
     return sql
-def run_sql_step(conn, name: str, sql: str, timeout: int = 300) -> Optional[List[Any]]:
+def run_sql_step(
+    conn, name: str, sql: str, timeout: int = ETLConstants.DEFAULT_SQL_TIMEOUT
+) -> Optional[List[Any]]:
     """Execute a single SQL statement and fetch any results.
     
     Args:
@@ -104,8 +105,8 @@ def run_sql_step_with_retry(
     conn,
     name: str,
     sql: str,
-    timeout: int = 300,
-    max_retries: int = MAX_RETRY_ATTEMPTS,
+    timeout: int = ETLConstants.DEFAULT_SQL_TIMEOUT,
+    max_retries: int = ETLConstants.MAX_RETRY_ATTEMPTS,
 ) -> Optional[List[Any]]:
     """Execute a SQL step with retry logic for transient ``pyodbc.Error`` failures."""
 
@@ -127,7 +128,9 @@ def run_sql_step_with_retry(
                 )
 
             time.sleep(2**attempt)
-def run_sql_script(conn, name: str, sql: str, timeout: int = 300):
+def run_sql_script(
+    conn, name: str, sql: str, timeout: int = ETLConstants.DEFAULT_SQL_TIMEOUT
+):
     """Execute a multi-statement SQL script.
     
     Args:
@@ -174,7 +177,12 @@ def run_sql_script(conn, name: str, sql: str, timeout: int = 300):
         logger.info(f"Script {name} failed after {elapsed:.2f} seconds")
         record_failure()
         raise SQLExecutionError(sql, e, table_name=name)
-def execute_sql_with_timeout(conn, sql: str, params: Optional[tuple] = None, timeout: int = 300) -> Any:
+def execute_sql_with_timeout(
+    conn,
+    sql: str,
+    params: Optional[tuple] = None,
+    timeout: int = ETLConstants.DEFAULT_SQL_TIMEOUT,
+) -> Any:
     """Execute SQL with parameters and timeout.
     
     Args:


### PR DESCRIPTION
## Summary
- define `ETLConstants` defaults in `config/settings.py`
- expose the constants from `config`
- use `ETLConstants` for SQL timeout, batch size and retry settings
- update tests to import the constants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c78a4a9d08323b59da9fa467ae3de