### PR TITLE
Add docstrings and README examples

### DIFF
--- a/01_JusticeDB_Import.py
+++ b/01_JusticeDB_Import.py
@@ -1,3 +1,11 @@
+"""ETL script to migrate Justice database tables to the target server.
+
+The script loads SQL files under ``sql_scripts/justice`` and executes them
+against the database specified via ``MSSQL_TARGET_CONN_STR``.  Command line
+arguments allow overriding the log file location, CSV directory and other
+options.
+"""
+
 import logging
 from utils.logging_helper import setup_logging, operation_counts
 import time

--- a/02_OperationsDB_Import.py
+++ b/02_OperationsDB_Import.py
@@ -1,3 +1,11 @@
+"""ETL script to migrate Operations database tables.
+
+The script reads SQL under ``sql_scripts/operations`` and applies it to the
+database defined by the ``MSSQL_TARGET_CONN_STR`` environment variable.  Command
+line arguments mirror those of ``01_JusticeDB_Import.py`` allowing CSV and log
+locations to be overridden.
+"""
+
 import logging
 from utils.logging_helper import setup_logging, operation_counts
 import time

--- a/03_FinancialDB_Import.py
+++ b/03_FinancialDB_Import.py
@@ -1,3 +1,10 @@
+"""ETL script to migrate Financial database tables to the target server.
+
+SQL files under ``sql_scripts/financial`` are executed in sequence.  Environment
+variables and command line options control the log path, CSV file location and
+whether empty tables are processed.
+"""
+
 import logging
 from utils.logging_helper import setup_logging, operation_counts
 import time

--- a/04_LOBColumns.py
+++ b/04_LOBColumns.py
@@ -1,3 +1,11 @@
+"""Optimize LOB columns for migration by determining appropriate sizes.
+
+This script analyzes large object columns in the target database and writes
+ALTER statements to resize them as needed.  It relies on configuration from
+``MSSQL_TARGET_CONN_STR`` and accepts command line options for logging and
+batch size.
+"""
+
 import logging
 from utils.logging_helper import setup_logging, operation_counts
 import time

--- a/README.md
+++ b/README.md
@@ -43,3 +43,24 @@ Error details are written to log files. By default the logs are created in the
 current working directory with names like `PreDMSErrorLog_Justice.txt`. Set the
 `EJ_LOG_DIR` environment variable to override the directory or pass a full path
 using the `--log-file` argument when running an individual script.
+
+## Examples
+
+Run the Justice ETL with a JSON configuration file and custom timeout. Empty
+tables are included by setting an environment variable:
+
+```bash
+SQL_TIMEOUT=600 INCLUDE_EMPTY_TABLES=1 \
+python 01_JusticeDB_Import.py --config-file config/values.json \
+  --log-file logs/justice.log
+```
+
+The Tk helper can run all scripts sequentially while still honouring the retry
+logic built into `utils/etl_helpers.run_sql_step_with_retry`:
+
+```bash
+SQL_TIMEOUT=600 python run_etl.py
+```
+
+If a transient `pyodbc.Error` occurs the command will be retried up to
+`ETLConstants.MAX_RETRY_ATTEMPTS` times.

--- a/db/mssql.py
+++ b/db/mssql.py
@@ -1,12 +1,17 @@
+"""Convenience wrappers for establishing MSSQL connections."""
+
 import pyodbc
 from config.settings import MSSQL_SOURCE_CONN_STR, MSSQL_TARGET_CONN_STR
 
 def get_mssql_connection(conn_str):
+    """Return a raw ``pyodbc`` connection using the given connection string."""
     return pyodbc.connect(conn_str)
 
 def get_source_connection():
+    """Connect to the source MSSQL database configured in settings."""
     return get_mssql_connection(MSSQL_SOURCE_CONN_STR)
 
 def get_target_connection():
+    """Connect to the target MSSQL database configured in settings."""
     return get_mssql_connection(MSSQL_TARGET_CONN_STR)
 

--- a/run_etl.py
+++ b/run_etl.py
@@ -1,3 +1,12 @@
+"""Graphical wrapper to run the ETL scripts sequentially.
+
+This module provides a small Tk based application that builds a SQL Server
+connection string and launches each of the ETL scripts.  It can also be used in
+headless mode by calling :func:`run_sequential_etl` with an environment
+dictionary.  The UI exposes the most common configuration options such as the
+CSV directory and whether empty tables should be processed.
+"""
+
 import os
 import sys
 import json
@@ -182,6 +191,7 @@ class ScriptRunner(threading.Thread):
 
 class App(tk.Tk):
     def __init__(self):
+        """Initialize the main application window and start queue processing."""
         super().__init__()
         self.title("EJ Supervision Importer")
         self.resizable(True, True)
@@ -251,6 +261,7 @@ class App(tk.Tk):
             print(f"Error saving config: {e}")
     
     def _create_connection_widgets(self):
+        """Create entry fields for connection parameters and CSV directory."""
         fields = ["Driver", "Server", "Database", "User", "Password"]
         self.entries = {}
         for i, field in enumerate(fields):
@@ -286,11 +297,13 @@ class App(tk.Tk):
         test_btn.grid(row=row+2, column=0, columnspan=2, pady=10)
     
     def _browse_csv_dir(self):
+        """Open a directory chooser dialog and store the selected path."""
         directory = filedialog.askdirectory()
         if directory:
             self.csv_dir_var.set(directory)
     
     def _show_script_widgets(self):
+        """Create buttons and status labels for each ETL script."""
         if hasattr(self, "script_frame"):
             return
 
@@ -359,6 +372,7 @@ class App(tk.Tk):
         self.output_text.insert(tk.END, f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] Ready to run scripts.\n\n")
     
     def _build_conn_str(self):
+        """Assemble a SQL Server ODBC connection string from the entry values."""
         driver = self.entries["driver"].get() or "{ODBC Driver 17 for SQL Server}"
         server = self.entries["server"].get()
         database = self.entries["database"].get()
@@ -375,6 +389,7 @@ class App(tk.Tk):
         return ";".join(parts)
     
     def test_connection(self):
+        """Validate the connection details entered by the user."""
         conn_str = self._build_conn_str()
         if not conn_str:
             messagebox.showerror("Error", "Please provide connection details")
@@ -406,6 +421,7 @@ class App(tk.Tk):
         self.output_text.insert(tk.END, f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] Output cleared.\n\n")
     
     def run_script(self, path):
+        """Launch the selected ETL script in a background thread."""
         if not self.conn_str:
             messagebox.showerror("Error", "Please test the connection first")
             return

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,1 +1,1 @@
-# Utility modules for ETL scripts
+"""Shared utility modules used by the ETL scripts."""

--- a/utils/etl_helpers.py
+++ b/utils/etl_helpers.py
@@ -1,3 +1,5 @@
+"""Helper functions for executing SQL statements with logging and retries."""
+
 import logging
 from utils.logging_helper import record_success, record_failure
 import os

--- a/utils/logging_helper.py
+++ b/utils/logging_helper.py
@@ -1,3 +1,5 @@
+"""Logging utilities with correlation IDs and success/failure counters."""
+
 import logging
 import uuid
 from contextvars import ContextVar


### PR DESCRIPTION
## Summary
- document modules and functions with docstrings
- clarify usage and retry logic in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7f58a2ec8323b65f2b3e2016508f