### PR TITLE
Validate SQL script path and add tests

### DIFF
--- a/tests/test_etl_helpers.py
+++ b/tests/test_etl_helpers.py
@@ -18,6 +18,7 @@ from utils.etl_helpers import (
     run_sql_step,
     run_sql_script,
     run_sql_step_with_retry,
+    load_sql,
     SQLExecutionError,
 )
 
@@ -91,3 +92,13 @@ def test_run_sql_step_with_retry_retries(monkeypatch):
         conn, 'test', 'SELECT 1', max_retries=ETLConstants.MAX_RETRY_ATTEMPTS
     )
     assert result == [('row',)]
+
+
+def test_load_sql_valid_path():
+    sql = load_sql('misc/gather_lobs.sql')
+    assert 'CREATE TABLE' in sql
+
+
+def test_load_sql_path_traversal():
+    with pytest.raises(ValueError):
+        load_sql('../utils/etl_helpers.py')

--- a/utils/etl_helpers.py
+++ b/utils/etl_helpers.py
@@ -47,8 +47,16 @@ def load_sql(filename: str, db_name: Optional[str] = None) -> str:
         SQL content with database name replaced if provided
     """
     base_dir = os.path.dirname(os.path.dirname(__file__)) if '__file__' in globals() else os.getcwd()
-    # The sql_scripts directory lives at the repo root
-    sql_path = os.path.join(base_dir, 'sql_scripts', filename)
+    scripts_dir = os.path.join(base_dir, 'sql_scripts')
+    # Normalize path to avoid path traversal outside sql_scripts
+    sql_path = os.path.abspath(os.path.normpath(os.path.join(scripts_dir, filename)))
+
+    # Ensure the final path is within the expected sql_scripts directory
+    scripts_dir_abs = os.path.abspath(scripts_dir)
+    if not sql_path.startswith(scripts_dir_abs + os.sep):
+        logger.error(f"Attempted SQL path traversal: {filename}")
+        raise ValueError(f"Invalid SQL file path: {filename}")
+
     if not os.path.exists(sql_path):
         logger.error(f"SQL file not found: {sql_path}")
         raise FileNotFoundError(f"SQL file not found: {sql_path}")


### PR DESCRIPTION
## Summary
- harden `load_sql` against path traversal
- test `load_sql` with valid and malicious inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca2ecd2808323acfe2052e90da706