### PR TITLE
Fix error prints in run_etl

### DIFF
--- a/run_etl.py
+++ b/run_etl.py
@@ -230,7 +230,7 @@ class App(tk.Tk):
                 with open(CONFIG_FILE, 'r') as f:
                     return json.load(f)
         except Exception as e:
-            print(f"Error loading config: {e}")
+            logger.error(f"Error loading config: {e}")
         return {
             "driver": "",
             "server": "",
@@ -258,7 +258,7 @@ class App(tk.Tk):
             with open(CONFIG_FILE, 'w') as f:
                 json.dump(config, f, indent=2)
         except Exception as e:
-            print(f"Error saving config: {e}")
+            logger.error(f"Error saving config: {e}")
     
     def _create_connection_widgets(self):
         """Create entry fields for connection parameters and CSV directory."""


### PR DESCRIPTION
## Summary
- use `logger.error` for config load/save errors in `run_etl.py`
- keep `setup_logging()` invocation before `App()` so logging is configured

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cab81463c8323a4e789cdb758851d