### PR TITLE
Remove unused tqdm imports

### DIFF
--- a/01_JusticeDB_Import.py
+++ b/01_JusticeDB_Import.py
@@ -18,7 +18,6 @@ import pandas as pd
 import urllib
 import sqlalchemy
 from db.mssql import get_target_connection
-from tqdm import tqdm
 from etl import core
 from etl import BaseDBImporter
 from sqlalchemy.types import Text

--- a/02_OperationsDB_Import.py
+++ b/02_OperationsDB_Import.py
@@ -20,7 +20,6 @@ import sqlalchemy
 from db.mssql import get_target_connection
 from etl import core
 from etl import BaseDBImporter
-from tqdm import tqdm
 from sqlalchemy.types import Text
 import tkinter as tk
 from tkinter import N, messagebox

--- a/03_FinancialDB_Import.py
+++ b/03_FinancialDB_Import.py
@@ -19,7 +19,6 @@ import sqlalchemy
 from db.mssql import get_target_connection
 from etl import core
 from etl import BaseDBImporter
-from tqdm import tqdm
 from sqlalchemy.types import Text
 import tkinter as tk
 from tkinter import N, messagebox

--- a/04_LOBColumns.py
+++ b/04_LOBColumns.py
@@ -17,7 +17,6 @@ import pandas as pd
 import urllib
 import sqlalchemy
 from db.mssql import get_target_connection
-from tqdm import tqdm
 from sqlalchemy.types import Text
 import tkinter as tk
 from tkinter import messagebox


### PR DESCRIPTION
## Summary
- strip `from tqdm import tqdm` from high-level importer scripts
- keep functionality intact and run tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cab861b208323ae2a90d1c17347d1