### PR TITLE
Fix typo in Financial importer

### DIFF
--- a/03_FinancialDB_Import.py
+++ b/03_FinancialDB_Import.py
@@ -108,7 +108,7 @@ class FinancialDBImporter(BaseDBImporter):
     
     def get_next_step_name(self):
         """Return the name of the next step in the ETL process."""
-        return "LOB Column Processling"
+        return "LOB Column Processing"
 
 def main():
     """Main entry point for Financial DB Import."""


### PR DESCRIPTION
## Summary
- correct typo in `FinancialDBImporter.get_next_step_name`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb297b5f48323b594fdbb989e400a